### PR TITLE
Style Attachment options

### DIFF
--- a/base.css
+++ b/base.css
@@ -15772,3 +15772,13 @@ body.styledGuildsAsChannels-DNHtg_ #app-mount .guilds-1SWlCJ .guildSeparator-3s6
     opacity: 1;
   }
 }
+
+.attachPopout-36hjtN{
+    transform: translateY(-50px);
+    color: var(--text-normal);
+    border-radius: 0px;
+    background: var(--background);
+}
+.attachPopoutRow-3iqqu1:hover{
+    background: var(--accent-solid);
+}


### PR DESCRIPTION
![Screenshot_20201101_125020](https://user-images.githubusercontent.com/42302831/97811527-cdbafb00-1c40-11eb-8f22-a96a160e61b3.png)

We need to use a Y Transform to get the upload options onto the screen:

![Screenshot_20201101_125132](https://user-images.githubusercontent.com/42302831/97811555-f8a54f00-1c40-11eb-85c8-737698c396a1.png)


Style the buttons to match the Slate theme: 

![Screenshot_20201101_125339](https://user-images.githubusercontent.com/42302831/97811598-4752e900-1c41-11eb-83f4-d5525bc62573.png)
