### PR TITLE
FIX: Call Icon Positioning and Powercord Spotify widget overlapp

### DIFF
--- a/src/channels/_panels.scss
+++ b/src/channels/_panels.scss
@@ -213,4 +213,12 @@
   .title-eS5yk3 {
     font-size: var(--font-size);
   }
+
+  // Powercord Spotify
+  .powercord-spotify.hover {
+    .spotify-extra-controls {
+        height:54;
+    }
+  }
+
 }

--- a/src/chat/_callvideo.scss
+++ b/src/chat/_callvideo.scss
@@ -354,6 +354,10 @@
             foreignObject {
                 mask:none;
             }
+            svg {
+                width:40px;
+                height:40px;
+            }
         }
     }
 }


### PR DESCRIPTION
There were some small problems on the controls in the voice chat
Before
![image](https://user-images.githubusercontent.com/19311856/110170554-aa74a800-7dfa-11eb-9b98-a9e175e060cf.png)

After
![image](https://user-images.githubusercontent.com/19311856/110170571-b52f3d00-7dfa-11eb-9bbc-b75b9be982b8.png)


There were also some overlapping in the Powercord spotify widget:
Before
![image](https://user-images.githubusercontent.com/19311856/110170869-1d7e1e80-7dfb-11eb-840d-5169ca6b7a1c.png)

After 
![image](https://user-images.githubusercontent.com/19311856/110170958-40103780-7dfb-11eb-9782-7eb43e0f2896.png)



