### PR TITLE
consistent spacing on mentioned and made compact more compact. also improved dev script with --path flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "slate",
       "version": "1.1.0",
       "license": "MIT",
       "dependencies": {

--- a/scripts/compile.js
+++ b/scripts/compile.js
@@ -16,7 +16,7 @@ module.exports = (options) => {
 	console.log(`Building ${options.target.join('/')} file...`);
 
 	// Check if path exists, if not make it.
-	const dirPath = options.output.filter(el => !el.includes('.')).join('/');
+	const dirPath = options.output.filter(el => !el.endsWith('.css')).join('/');
 	if (!fs.existsSync(!dirPath)) {
 		fs.mkdirSync(dirPath, {recursive: true});
 	}

--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -6,7 +6,12 @@ const compile = require('./compile');
 const {name, dev} = require('./config.json');
 
 const dataFolder = process.env.APPDATA || (process.platform == 'darwin' ? process.env.HOME + '/Library/Application Support' : process.env.HOME + "/.local/share");
-const themesFolder = path.join(dataFolder, 'BetterDiscord', 'themes');
+let themesFolder = path.join(dataFolder, 'BetterDiscord', 'themes');
+
+const pathFlagIndex = process.argv.findIndex(el => el === '--path');
+if (pathFlagIndex !== -1) {
+	themesFolder = process.argv[pathFlagIndex + 1];
+}
 
 chokidar.watch('src', {persistent: true})
 	.on('ready', () => console.log(`Watching for changes...`))

--- a/src/_root.scss
+++ b/src/_root.scss
@@ -25,6 +25,7 @@
 	--spacing: 10px;
 	--spacing-double: calc(var(--spacing) * 2);
 	--spacing-triple: calc(var(--spacing) * 3);
+	--spacing-compact: 2px;
 
 	// Fonts
 	--font-family-sans-serif: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", Arial, sans-serif;

--- a/src/chat/_messages.scss
+++ b/src/chat/_messages.scss
@@ -18,6 +18,9 @@
 				margin-top: 0;
 			}
 		}
+		&.compact-T3H92H {
+			padding: var(--spacing-compact) 0 var(--spacing-compact) 70px;
+		}
 		.username-1A8OIy {
 			font-size: var(--chat-font-size);
 			color: var(--text-normal);
@@ -42,7 +45,7 @@
 				padding-bottom: 4px;
 			}
 			&.compact-T3H92H {
-				padding-bottom: calc(var(--spacing) + 5px);
+				padding-bottom: var(--spacing-compact);
 			}
 			&:before {
 				background-color: var(--accent-solid);
@@ -58,7 +61,7 @@
 			margin-top: calc(var(--spacing) / -1);
 			padding-top: 0;
 		}
-		&:last-child {
+		&:last-child:not(.compact-T3H92H) {
 			padding-bottom: calc(var(--spacing) + 5px);
 		}
 
@@ -290,7 +293,7 @@
 
 	// Compact
 	.compact-T3H92H {
-		padding: var(--spacing) 0 var(--spacing) 70px;
+		padding: var(--spacing) 0 var(--spacing-third) 70px;
 		.contents-2mQqc9 {
 			padding-left: 0;
 			margin: 0;

--- a/src/chat/_messages.scss
+++ b/src/chat/_messages.scss
@@ -39,6 +39,9 @@
 				padding-top: 0;
 			}
 			&:not(:nth-last-child(2)) {
+				padding-bottom: 4px;
+			}
+			&.compact-T3H92H {
 				padding-bottom: calc(var(--spacing) + 5px);
 			}
 			&:before {

--- a/src/chat/_messages.scss
+++ b/src/chat/_messages.scss
@@ -39,7 +39,7 @@
 				padding-top: 0;
 			}
 			&:not(:nth-last-child(2)) {
-				padding-bottom: 4px;
+				padding-bottom: calc(var(--spacing) + 5px);
 			}
 			&:before {
 				background-color: var(--accent-solid);

--- a/src/chat/_reactions.scss
+++ b/src/chat/_reactions.scss
@@ -2,6 +2,7 @@
 
 #app-mount {
 	.reactions-12N0jA {
+		height: 16px;
 		margin: 0;
 		padding: 0;
 		.reactionBtn-3N03Zj {

--- a/src/chat/_reactions.scss
+++ b/src/chat/_reactions.scss
@@ -2,7 +2,6 @@
 
 #app-mount {
 	.reactions-12N0jA {
-		height: 16px;
 		margin: 0;
 		padding: 0;
 		.reactionBtn-3N03Zj {


### PR DESCRIPTION
It bugged me how the cozy layout was more compact than the compact layout. Also inconsistent spacing on mentioned messages.

I hope this change is welcome.

Before:
![image](https://user-images.githubusercontent.com/3050747/145099584-4dad27e2-1a4f-4a85-ad4e-9e5e286168a4.png)


After:
![image](https://user-images.githubusercontent.com/3050747/145099626-4f03aab2-80cd-4e51-b5ef-b28fec3f1e0f.png)


I also made the dev script support a --path flag, to support custom paths to the theme directory.