### PR TITLE
fix: add Slate.theme.css

### DIFF
--- a/dist/Slate.theme.css
+++ b/dist/Slate.theme.css
@@ -1,0 +1,12 @@
+@import url("https://discordstyles.github.io/AdjustableServerWidth/base.css");
+@import url("https://discordstyles.github.io/Slate/dist/Slate.css");
+:root {
+    /* Primary Colors */
+    --accent: 3, 102, 214;
+    --link-colour: 48, 144, 255;
+  
+    /* Server List */
+    --server-icon-size: 35px;
+    --server-icon-spacing: 8px;
+    --server-container-padding: 10px;
+  }

--- a/dist/Slate.theme.css
+++ b/dist/Slate.theme.css
@@ -11,7 +11,7 @@
 /*
   Import Source Code 
 */
-@import url("https://discordstyles.github.io/AdjustableServerWidth/base.css");
+@import url("https://github.com/Xanthus58/Slate/blob/Issue-99-Fix/dist/Slate.css");
 @import url("https://discordstyles.github.io/Slate/dist/Slate.css");
 
 /*

--- a/dist/Slate.theme.css
+++ b/dist/Slate.theme.css
@@ -1,12 +1,34 @@
+/**
+ * @name Slate
+ * @author Gibbu#1211 & Tropical#8908
+ * @version 1.1
+ * @invite TeRQEPb
+ * @description An optimized, consistent, and functional theme for Discord based on GitHub's design language.
+ * @source https://github.com/DiscordStyles/Slate/
+ * @website https://discordstyles.github.io/slate-theme/
+*/
+
+/*
+  Import Source Code 
+*/
 @import url("https://discordstyles.github.io/AdjustableServerWidth/base.css");
 @import url("https://discordstyles.github.io/Slate/dist/Slate.css");
+
+/*
+  Basic Variables
+  See available vars here: https://github.com/DiscordStyles/Slate/wiki
+*/
 :root {
-    /* Primary Colors */
-    --accent: 3, 102, 214;
-    --link-colour: 48, 144, 255;
-  
-    /* Server List */
-    --server-icon-size: 35px;
-    --server-icon-spacing: 8px;
-    --server-container-padding: 10px;
-  }
+  /* Primary Colors */
+  --accent: 3, 102, 214;
+  --link-colour: 48, 144, 255;
+
+  /* Server List */
+  --server-icon-size: 35px;
+  --server-icon-spacing: 8px;
+  --server-container-padding: 10px;
+}
+
+/*
+  Place any Theme-specific Custom CSS Below here
+*/

--- a/dist/Slate.theme.css
+++ b/dist/Slate.theme.css
@@ -11,7 +11,7 @@
 /*
   Import Source Code 
 */
-@import url("https://github.com/Xanthus58/Slate/blob/Issue-99-Fix/dist/Slate.css");
+@import url("https://discordstyles.github.io/AdjustableServerWidth/base.css");
 @import url("https://discordstyles.github.io/Slate/dist/Slate.css");
 
 /*

--- a/powercord_manifest.json
+++ b/powercord_manifest.json
@@ -1,7 +1,7 @@
 {
     "name": "Slate",
     "description": "An optimized, consistent, and functional theme for Discord based on GitHub's design language.",
-    "version": "1.1.7",
+    "version": "1.1.8",
     "author": "Gibbu#1211 & Tropical#8908",
     "theme": "dist/Slate.theme.css",
     "consent": ["ext_listing"],


### PR DESCRIPTION
The powercord_manifest.json file was pointing the "theme" to a non-existent file. The fix was easy; I just re-implemented the original file that was missing.

I have also increased the version number so users of Slate on Powercord are now aware of an updated version and can install it accordingly.

Fixes issue: https://github.com/DiscordStyles/Slate/issues/97