### PR TITLE
Fix: Spelling mistake in the bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -16,7 +16,7 @@ assignees: ''
 ### Screenshots
 *If applicable, add screenshots to help explain your problem*
 
-### Infomation (please complete the following information)
+### Information (please complete the following information)
 **Discord channel**: *Stable/PTB/Canary*  
 **OS**: *Windows/Linux/OSX*  
 **Mod**: *BetterDiscord/Powercord/GooseMod*  


### PR DESCRIPTION
As I was filing a bug report I noticed a very minor spelling mistake in the template. That this PR fixes