### PR TITLE
Fixed bugs in the status options

### DIFF
--- a/src/theme/popouts/_statuspicker.scss
+++ b/src/theme/popouts/_statuspicker.scss
@@ -69,6 +69,14 @@
 				.status-2DiCMd[style="background-color: rgb(116, 127, 141);"] {
 					background: rgb(var(--status-grey)) !important;
 				}
+				//Gets rid of the text bellow do not disturb status
+				.description-1Dd2kv {
+    					font-size: 0px;
+				}
+				//Centers the status options 
+				.statusItem-38ArJn {
+    					padding: 1px 8px;
+				}
 			}
 			.statusIconText-3b4TkH {
 				height: auto;


### PR DESCRIPTION
Removed the text below the do not disturb status, and centered the items so it looks better.

Before:
![Before](https://user-images.githubusercontent.com/69062137/183729240-dcd000ef-2e2b-41a0-855f-44bdbbf05b3c.png)

After:
![After](https://user-images.githubusercontent.com/69062137/183729265-6bfe8721-f069-4688-a7fd-a11647c6eeaf.png)

