### PR TITLE
Fixed spacing problem in inbox

### DIFF
--- a/src/theme/chat/_messages.scss
+++ b/src/theme/chat/_messages.scss
@@ -58,7 +58,7 @@
 			}
 		}
 		&.cozy-VmLDNB:not(.groupStart-3Mlgv1) {
-			margin-top: calc(var(--spacing) / -1);
+			margin-top: 5px;
 			padding-top: 0;
 		}
 


### PR DESCRIPTION
There was a problem previously where the name of the replier would be cut off in the inbox. Changing the margin fixes that issue; there is however a tradeoff, in doing this there is a 5px loss per message in the chat because they use the same CSS class. Previously the margin was -10, but this gets cut off in the inbox, -5 is the lowest number that doesn't cut off the name but does have that trade-off. It's not all that noticeable though.

Before inbox:
![Patch3-before](https://user-images.githubusercontent.com/69062137/183748415-f574e1d5-3e18-4250-bb6e-43abb29d7b73.png)

After inbox:
![Patch3-After](https://user-images.githubusercontent.com/69062137/183748452-25d87608-6394-44ab-ae79-074f4473ee4e.png)

Before Chat: 
![Patch3-chat-before](https://user-images.githubusercontent.com/69062137/183748525-e41707ed-f9a1-49f8-9a76-14e6ff53e961.png)

After Chat:
![Patch3-chat-after](https://user-images.githubusercontent.com/69062137/183748544-726bd4b2-ce69-4683-9050-c1392bdac14f.png)

