### PR TITLE
Fixed the text encroaching on the quoted message in inbox

### DIFF
--- a/src/theme/chat/_messages.scss
+++ b/src/theme/chat/_messages.scss
@@ -730,9 +730,11 @@
 		width: fit-content;
 		margin-left: -5px;
 		max-width: calc(100vw - (var(--sidebar-width) * 3));
-		padding: var(--spacing-third) var(--spacing-half);
-		border-radius: 0 var(--border-radius) var(--border-radius)
-			var(--border-radius);
+		border-radius: 0 var(--border-radius) var(--border-radius) var(--border-radius);
+		padding: 1px;
+    		padding-left: 3.5px;
+    		padding-right: 4px;
+		
 		& > div {
 			position: relative;
 			z-index: 1;
@@ -767,7 +769,7 @@
 			border-right: none;
 		}
 		& + .contents-2MsGLg .header-2jRmjb {
-			margin-bottom: 32px;
+			margin-bottom: 34px;
 		}
 	}
 	.repliedTextContent-2hOYMB {


### PR DESCRIPTION
There was a bug previously where the reply to a message would encroach on the original quoted message in the inbox. I fixed it by changing the margin around that quoted message by about 2px, and I changed the padding around that quoted message. This was important because it decreases the amount of space lost in chat. Unfortunately, because every message in both the inbox and chat uses the same CSS changing one affects the other, but by shrinking the padding I think the loss is limited to a few pixels per replied message in chat, and it's hardly noticeable (This is also using changes from my other PR which fixes the spacing in the inbox). I will also add that I don't think the inbox looks perfect or anything, there is still too little space between the two messages but there isn't much to be done about that without either major changes or loss of space within the chat which I personally find more important than the inbox.

Before inbox:
![Patch3-before](https://user-images.githubusercontent.com/69062137/183748836-380f8876-9988-4ccf-99c3-40e8706af321.png)

After inbox:
![Patch4-after-inbox](https://user-images.githubusercontent.com/69062137/183749202-93809fef-2637-466d-8cd2-74c78c474782.png)


Before Chat:
![Patch4-chat-before](https://user-images.githubusercontent.com/69062137/183748998-6f635c7e-0d89-4707-bacf-3a7a55c2c062.png)

After Chat:
![Patch4-after-chat](https://user-images.githubusercontent.com/69062137/183749340-2e826f92-1e87-4928-bed1-45d24572c337.png)

 