### PR TITLE
Fixed role remove icon displacement

### DIFF
--- a/src/theme/popouts/_userpopout.scss
+++ b/src/theme/popouts/_userpopout.scss
@@ -227,6 +227,7 @@
 		height: auto;
 		height: 22px;
 		background: transparent;
+		padding-left: 17px;
 		&:hover .roleCircle-3K9O3d,
 		&:active .roleCircle-3K9O3d {
 			opacity: 1;
@@ -246,7 +247,7 @@
 			border-radius: var(--border-radius);
 			position: absolute;
 			top: 0;
-			left: 0;
+			left: 10px;
 			width: 100%;
 			height: 100%;
 			opacity: 0.75;
@@ -255,12 +256,19 @@
 				position: relative;
 				z-index: 10;
 				background: inherit;
-				width: 100%;
-				height: 100%;
 				padding: var(--spacing-third);
 				box-sizing: border-box;
 				opacity: 0;
 				border-radius: 50px;
+				width: 10px;
+    				height: 100%;
+    				top: 5px;
+    				left: -5px;
+    				margin: -5px 0 0 -5px;
+   				background-color: var(--background-dark);
+    				border: 1px solid var(--background-dark);
+    				border-left: 11px solid var(--background-dark);
+				
 				path {
 					fill: var(--white);
 					transform: scale(0.75);
@@ -281,10 +289,12 @@
 		}
 	}
 	.actionButton-1YKTU0 {
-		position: absolute;
+		position: absolute!important;
 		top: calc(var(--spacing-triple) / -1 - var(--spacing-half) - 2px);
+		top: -34px;
 		right: 0;
 		padding: 0 var(--spacing);
+		padding-left: 0px!important;
 		margin: 0;
 		border-radius: 0;
 		background: transparent;


### PR DESCRIPTION
Previously the role remove icon would be placed in the center of the role on a user's popup, now it is nicely displayed on the side like in normal discord. There is of course a matter of preference to whether or not you like the way the roles look without hovering over them. Personally, I think they look nice and the subtle change from hovering over them is satisfying.

Before without hovering:
![Patch5-before-nohover](https://user-images.githubusercontent.com/69062137/183777781-be9d6784-7fee-4a14-ac1b-6af25395e0dd.png)

Before hovering over the role:
![Patch5-before-hovering](https://user-images.githubusercontent.com/69062137/183777826-8df57453-799f-412d-b8f4-e5ac3abb3714.png)


After without hovering:
![Patch5-after-nohover](https://user-images.githubusercontent.com/69062137/183777539-f9fbb58c-e258-42ca-8b2b-50333d074186.png)

After hovering over the role:
![Patch5-after-hovering](https://user-images.githubusercontent.com/69062137/183777625-008e8d12-b2fb-4785-94e9-7f1042e9e641.png)

