### PR TITLE
Fixed the bot add to server button

### DIFF
--- a/src/theme/inputs/_button.scss
+++ b/src/theme/inputs/_button.scss
@@ -27,6 +27,7 @@
 		color: var(--white);
 		background-color: rgb(var(--accent));
 		margin-left: var(--spacing);
+		width: 93.5%;
 		&:hover {
 			box-shadow: inset 0 0 0 100vmax rgba(255, 255, 255, 0.1);
 		}


### PR DESCRIPTION
The bot add to server button displayed in the bot's popout would previously overflow and looked off. I just changed the width to even it out.