### PR TITLE
Fixed misaligned icons

### DIFF
--- a/src/theme/sidebar/_panels.scss
+++ b/src/theme/sidebar/_panels.scss
@@ -23,6 +23,7 @@
 		border-radius: 0;
 		transition: none;
 		cursor: var(--cursor);
+		padding-top: 3px;
 		svg {
 			height: 16px;
 			color: var(--text-normal);


### PR DESCRIPTION
On the panel with mute, deafen, and settings the icons were a little too high, so I moved them down a little.

Before:
![Patch7-before](https://user-images.githubusercontent.com/69062137/183781457-72812a58-6bb6-4a46-b1ec-90d5aadb28de.png)

After:
![Patch7-after](https://user-images.githubusercontent.com/69062137/183781469-0871b018-3d05-4aff-a173-ff99178ce119.png)

